### PR TITLE
There was a missing options parameter in Room.create, and that was no…

### DIFF
--- a/colyseus/client.lua
+++ b/colyseus/client.lua
@@ -70,8 +70,8 @@ function client:create_connection(path, options)
   options = options or {}
 
   local params = { "colyseusid=" .. storage.get_item("colyseusid") }
-  for k, options in pairs(options) do
-    table.insert(params, k .. "=" .. options[k])
+  for k, v in pairs(options) do
+    table.insert(params, k .. "=" .. v)
   end
 
   pprint(self.hostname .. path .. "?" .. table.concat(params, "&"))

--- a/colyseus/room.lua
+++ b/colyseus/room.lua
@@ -10,10 +10,10 @@ local storage = require('colyseus.storage')
 Room = {}
 Room.__index = Room
 
-function Room.create(name)
+function Room.create(name, options)
   local room = StateContainer.new()
   setmetatable(room, Room)
-  room:init(name)
+  room:init(name, options)
   return room
 end
 


### PR DESCRIPTION
…t getting passed to init.  Adding this fixes my issue where options are not getting sent to onAuth on the server side.

Also ran into an issue in client where options were getting inserted into params table, it started throwing "attempt to concatenate field '?' (a nil value)" errors.  I noticed the loop was using the variable options as well, changed that to v and it works properly.